### PR TITLE
feat: extend RCTPlugin with dynamic context() and trigger() support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ src/
 │   ├── hook.ts          # createHook() — managed hook lifecycle wrapper
 │   └── register.ts      # standard(), dynamic(), block() — low-level hook I/O helpers
 ├── plugin/
-│   ├── types.ts         # RCTPlugin interface: { name, files?, rules? }
+│   ├── types.ts         # RCTPlugin interface: { name, files?, rules?, context?, trigger? }
 │   ├── index.ts         # Plugin registry (built-in plugins)
 │   ├── resolve.ts       # Plugin resolution: built-in → local → package
 │   ├── issueScope.ts    # Built-in "issue-scope" plugin
@@ -109,12 +109,14 @@ test/                    # 27 test files
 1. Claude Code fires a hook → `rct hook <HookEvent>` runs
 2. Async events (PreToolUse, PostToolUse, …) receive a JSON payload on stdin
 3. `cli/hook.ts` loads and validates `rct.config.{ts,js,json}` from `CLAUDE_PROJECT_DIR`
-4. **Rules** evaluated first — `action: "block"` outputs `{ decision: "block", reason }` and exits 2
-5. **Injections** evaluated — matching entries resolve `FileRef[]` from the registry
-6. **Lang** evaluated — per-language modules (node/python/rust) extract tool info and config paths
-7. **Test** runner invoked per language with top-level inheritance, results cached per session
-8. **Meta** summary generated if configured (reads from resolved config, not hardcoded registry)
-9. All parts assembled into `{ hookSpecificOutput: { hookEventName, additionalContext } }`, minified, written to stdout
+4. **Plugin triggers** evaluated — each plugin's `trigger()` function called with 5s timeout; block exits immediately, warn messages collected
+5. **Rules** evaluated — static `action: "block"` outputs `{ decision: "block", reason }` and exits 2
+6. **Injections** evaluated — matching entries resolve `FileRef[]` from the registry
+7. **Plugin contexts** evaluated — each plugin's `context()` function called with 5s timeout; non-undefined results collected
+8. **Lang** evaluated — per-language modules (node/python/rust) extract tool info and config paths
+9. **Test** runner invoked per language with top-level inheritance, results cached per session
+10. **Meta** summary generated if configured (reads from resolved config, not hardcoded registry)
+11. All parts assembled into `{ hookSpecificOutput: { hookEventName, additionalContext } }`, minified, written to stdout
 
 ## Config File (Consumer-Facing)
 
@@ -133,7 +135,17 @@ End users create `rct.config.json` (or `.ts`/`.js`) via `rct init`:
 
 ### Plugins
 
-Plugins are declarative (contribute `files[]` and `rules[]`). Extensions are imperative (custom hook scripts using `createHook()` or `standard`/`dynamic`/`block`).
+Plugins can be declarative (contribute `files[]` and `rules[]`) and/or dynamic (provide `context()` and `trigger()` functions). Extensions are imperative (custom hook scripts using `createHook()` or `standard`/`dynamic`/`block`).
+
+**Plugin interface (`RCTPlugin`):**
+
+- `name` — plugin identifier
+- `files?` — file entries to merge into config
+- `rules?` — rule entries to merge into config
+- `context?(event, input)` — returns dynamic context string (or undefined); called with 5s timeout
+- `trigger?(event, input)` — returns `{ action: 'block'|'warn', message }` (or undefined); called with 5s timeout
+
+`PluginHookInput`: `{ toolName?: string, payload: Record<string, unknown> }`
 
 **Built-in plugins** (`globals.plugins`):
 

--- a/docs/superpowers/plans/2026-03-31-stream2-rct-dynamic-content.md
+++ b/docs/superpowers/plans/2026-03-31-stream2-rct-dynamic-content.md
@@ -21,17 +21,26 @@
 ```typescript
 import type { RCTConfig, HookEvent, RuleAction } from '#config/types'
 
+/** Result from a plugin's dynamic trigger function. */
 export interface PluginTriggerResult {
     action: RuleAction
     message: string
 }
 
+/** Input passed to plugin context/trigger functions — matches what the hook pipeline actually has. */
+export interface PluginHookInput {
+    toolName?: string
+    payload: Record<string, unknown>
+}
+
 export interface RCTPlugin extends Pick<RCTConfig, 'rules' | 'files'> {
     name: string
-    context?: (event: HookEvent, input: RC.HookInput) => string | Promise<string> | undefined
-    trigger?: (event: HookEvent, input: RC.HookInput) => PluginTriggerResult | Promise<PluginTriggerResult> | undefined
+    context?: (event: HookEvent, input: PluginHookInput) => string | undefined | Promise<string | undefined>
+    trigger?: (event: HookEvent, input: PluginHookInput) => PluginTriggerResult | undefined | Promise<PluginTriggerResult | undefined>
 }
 ```
+
+**Note:** We use `PluginHookInput` (not `RC.HookInput`) because the hook pipeline in `cli/hook.ts` never constructs an `RC.HookInput` object. It reads stdin into `Record<string, unknown>` and extracts `toolName`. `RC.HookInput` is only used by the imperative extension API (`createHook`, `standard`, `dynamic`, `block`), which is a separate code path.
 
 **Files to create:**
 - `test/plugin-dynamic.test.ts` — tests for both new capabilities
@@ -39,12 +48,13 @@ export interface RCTPlugin extends Pick<RCTConfig, 'rules' | 'files'> {
 **Tests (write first — TDD):**
 
 *context:*
-- Plugin with `context` function is valid
+- Plugin with `context` function is valid (type-checks)
 - Plugin without `context` function still works (backwards compatible)
 - `context` returning `undefined` produces no output
 - `context` returning a string appends to additionalContext
 - `context` that throws is caught and warned (not fatal)
 - Async `context` functions are awaited
+- `context` that exceeds timeout (5s) is treated as undefined with warning
 
 *trigger:*
 - Plugin with `trigger` function is valid
@@ -54,6 +64,7 @@ export interface RCTPlugin extends Pick<RCTConfig, 'rules' | 'files'> {
 - `trigger` returning `{ action: 'warn', message }` adds a warning
 - `trigger` that throws is caught and warned (not fatal)
 - Async `trigger` functions are awaited
+- `trigger` that exceeds timeout (5s) is treated as undefined with warning
 - `trigger` block takes precedence over static rule warn (highest severity wins)
 
 ### Step 2: Thread `context` and `trigger` through plugin resolution
@@ -61,35 +72,52 @@ export interface RCTPlugin extends Pick<RCTConfig, 'rules' | 'files'> {
 **Files to modify:**
 - `src/config/schema.ts` (`applyPlugins`) — preserve `context` and `trigger` functions from resolved plugins alongside files/rules
 
-Currently `applyPlugins` merges `files[]` and `rules[]` into the config. It needs to also collect `context` and `trigger` functions into arrays that the hook pipeline can call.
+Currently `applyPlugins` merges `files[]` and `rules[]` into the config and returns the merged config. It needs to also collect `context` and `trigger` functions.
 
 **Approach:** Return a `PluginExtensions` object alongside the merged config:
 
 ```typescript
-interface PluginExtensions {
-    contexts: Array<{ name: string; fn: RCTPlugin['context'] }>
-    triggers: Array<{ name: string; fn: RCTPlugin['trigger'] }>
+export interface PluginExtensions {
+    contexts: Array<{ name: string; fn: NonNullable<RCTPlugin['context']> }>
+    triggers: Array<{ name: string; fn: NonNullable<RCTPlugin['trigger']> }>
 }
-```
 
-The hook pipeline receives this alongside the config.
+// applyPlugins returns { config, extensions }
+```
 
 **Tests:**
 - `applyPlugins` preserves `context` and `trigger` functions
 - Multiple plugins with both functions all collected
 - Plugin with only `context` or only `trigger` (no files/rules) works
 - Plugin with none of the dynamic functions still works (backwards compat)
+- Functions are paired with plugin names for error attribution
 
 ### Step 3: Integrate into hook pipeline
 
 **Files to modify:**
 - `src/cli/hook.ts` — call plugin `context()` and `trigger()` functions during pipeline evaluation
+- `src/engine/compose.ts` — add `pluginContextResults: string[]` field to `ComposeInput`, include in parts assembly after injections and before meta
 
 **Integration points:**
 
-*context:* After `evaluateInjections()` and before `composeOutput()`. For each plugin with a `context` function, call it with the current event and input. Collect non-undefined results into the parts array.
+*trigger:* During or immediately after `evaluateRules()` phase. For each plugin with a `trigger` function, call it with `{ toolName, payload }` wrapped in `Promise.race` with 5s timeout. If it returns a block, exit with block decision. If it returns a warn, add to warnings. Severity ordering: block > warn > undefined.
 
-*trigger:* During `evaluateRules()` phase (or immediately after). For each plugin with a `trigger` function, call it with the current event and input. If it returns a block, exit with block decision. If it returns a warn, add to warnings. Severity ordering: block > warn > undefined.
+*context:* After `evaluateInjections()` and before `composeOutput()`. For each plugin with a `context` function, call it with `{ toolName, payload }` wrapped in `Promise.race` with 5s timeout. Collect non-undefined results into `pluginContextResults`.
+
+**Timeout helper:**
+```typescript
+async function withTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T | undefined> {
+    try {
+        return await Promise.race([
+            fn(),
+            new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms))
+        ])
+    } catch (err) {
+        console.warn(`[rct] Warning: ${label}: ${err instanceof Error ? err.message : err}`)
+        return undefined
+    }
+}
+```
 
 **Tests:**
 - End-to-end hook test with plugin providing dynamic context
@@ -97,7 +125,8 @@ The hook pipeline receives this alongside the config.
 - End-to-end hook test with plugin providing dynamic trigger (warn)
 - Plugin context/trigger errors are caught and logged, don't block pipeline
 - Plugin trigger block overrides static rule warn
-- Plugin outputs included in composed output
+- Plugin outputs included in composed output via `pluginContextResults`
+- Timeout test: context function that hangs is killed after 5s
 
 ### Step 4: Fix pre-existing issues
 
@@ -106,7 +135,7 @@ These touch the same files we're already modifying.
 #### 4a: Plugin error visibility (`src/config/schema.ts:110-119`)
 
 **Current:** `console.warn(`[rct] Failed to resolve plugin '${name}': ${...}`)`
-**Fix:** Add `[rct] Warning:` prefix consistently. Check for `RCT_DEBUG` env var — if set, log full stack trace.
+**Fix:** Ensure consistent `[rct] Warning:` prefix. Check for `RCT_DEBUG` env var — if set, log full stack trace via `console.warn`.
 
 **Test:** Verify warning format, verify debug mode shows stack trace.
 
@@ -117,35 +146,38 @@ These touch the same files we're already modifying.
 
 **Test:** Verify warning emitted for unresolvable refs.
 
-#### 4c: Unused `staleCheck.format` parameter (`src/config/schema.ts`)
+#### 4c: Unused `staleCheck.format` parameter
 
-**Current:** `format?: string` accepted but never used.
-**Fix:** Remove `format` from `StaleCheckConfig` type in `src/config/types.ts`. Check if any test or config references it.
+**Current:** `format?: string` exists as an inline property of `FileEntry.staleCheck` at `src/config/types.ts:75-81`. Also accepted in `applyStaleCheck` parameter type at `src/config/schema.ts:182`.
+**Fix:** Remove `format` from both locations. Check if any test or config references it.
 
-**Test:** Verify type no longer accepts `format`.
+**Test:** Verify type no longer accepts `format`. Existing stale check tests still pass.
 
 ### Step 5: Update tests + documentation
 
 - Run full `bun test` suite — ensure no regressions
 - Update `CLAUDE.md` architecture section to mention plugin `context` and `trigger` capabilities
-- Update plugin section in `README.md` with examples
+- Update plugin section with interface documentation
 - Lint + format
 
 ## Build Sequence
 
 ```
-Step 1 (interface) → Step 2 (resolution) → Step 3 (pipeline integration)
-                                          → Step 4 (pre-existing fixes, parallel with Step 3)
-                                          → Step 5 (tests + docs)
+Step 1 (interface + types) → Step 2 (resolution) → Step 3 (pipeline + compose.ts)
+                                                  → Step 4 (pre-existing fixes, parallel with Step 3)
+                                                  → Step 5 (tests + docs)
 ```
 
-Steps 3 and 4 can run in parallel — they touch different files (hook.ts vs schema.ts/injections.ts/types.ts).
+Steps 3 and 4 can run in parallel — they touch different files:
+- Step 3: `hook.ts`, `compose.ts`
+- Step 4: `schema.ts`, `injections.ts`, `config/types.ts`
 
 ## Touch Point with Stream 1
 
 After this lands, a follow-up PR updates `rct-plugin-tmux/src/index.ts`:
 
 ```typescript
+import type { RCTPlugin } from 'reactive-context-toolkit'
 import { listPanes, formatLayoutSummary } from './lib/tmux'
 
 export default {
@@ -159,8 +191,8 @@ export default {
         }
     },
     trigger: async (event, input) => {
-        // v2: warn if Bash command conflicts with a watched pane process
+        // v2: warn if Bash command conflicts with a watched pane
         return undefined
     }
-}
+} satisfies RCTPlugin
 ```

--- a/docs/superpowers/plans/2026-03-31-stream2-rct-dynamic-content.md
+++ b/docs/superpowers/plans/2026-03-31-stream2-rct-dynamic-content.md
@@ -19,11 +19,11 @@
 - `src/plugin/types.ts` — add optional `context` and `trigger` functions to `RCTPlugin`
 
 ```typescript
-import type { RCTConfig, HookEvent, RuleAction } from '#config/types'
+import type { RCTConfig, HookEvent } from '#config/types'
 
 /** Result from a plugin's dynamic trigger function. */
 export interface PluginTriggerResult {
-    action: RuleAction
+    action: 'block' | 'warn'
     message: string
 }
 

--- a/docs/superpowers/plans/2026-03-31-stream2-rct-dynamic-content.md
+++ b/docs/superpowers/plans/2026-03-31-stream2-rct-dynamic-content.md
@@ -1,34 +1,44 @@
-# Implementation Plan: Stream 2 — rct Plugin Dynamic Content Enhancement
+# Implementation Plan: Stream 2 — rct Plugin Dynamic Content & Triggers Enhancement
 
 **Spec:** `docs/superpowers/specs/2026-03-31-rct-plugin-tmux-design.md` (Stream 2 section)
 **Branch:** `feat/plugin-dynamic-context`
-**Issue:** TBD (created during setup)
-**Draft PR:** TBD (created during setup)
+**Issue:** #8
+**Draft PR:** #9
 
 ## Prerequisites
 
-- [ ] Create feature branch `feat/plugin-dynamic-context` from `main`
-- [ ] Create GitHub issue for tracking
-- [ ] Create draft PR linked to issue
+- [x] Create feature branch `feat/plugin-dynamic-context` from `main`
+- [x] Create GitHub issue for tracking
+- [x] Create draft PR linked to issue
 
 ## Steps
 
 ### Step 1: Extend `RCTPlugin` interface
 
 **Files to modify:**
-- `src/plugin/types.ts` — add optional `context` function to `RCTPlugin`
+- `src/plugin/types.ts` — add optional `context` and `trigger` functions to `RCTPlugin`
 
 ```typescript
+import type { RCTConfig, HookEvent, RuleAction } from '#config/types'
+
+export interface PluginTriggerResult {
+    action: RuleAction
+    message: string
+}
+
 export interface RCTPlugin extends Pick<RCTConfig, 'rules' | 'files'> {
     name: string
     context?: (event: HookEvent, input: RC.HookInput) => string | Promise<string> | undefined
+    trigger?: (event: HookEvent, input: RC.HookInput) => PluginTriggerResult | Promise<PluginTriggerResult> | undefined
 }
 ```
 
 **Files to create:**
-- `test/plugin-dynamic-context.test.ts` — tests for the new capability
+- `test/plugin-dynamic.test.ts` — tests for both new capabilities
 
 **Tests (write first — TDD):**
+
+*context:*
 - Plugin with `context` function is valid
 - Plugin without `context` function still works (backwards compatible)
 - `context` returning `undefined` produces no output
@@ -36,32 +46,58 @@ export interface RCTPlugin extends Pick<RCTConfig, 'rules' | 'files'> {
 - `context` that throws is caught and warned (not fatal)
 - Async `context` functions are awaited
 
-### Step 2: Thread `context` through plugin resolution
+*trigger:*
+- Plugin with `trigger` function is valid
+- Plugin without `trigger` function still works
+- `trigger` returning `undefined` takes no action
+- `trigger` returning `{ action: 'block', message }` blocks the tool use
+- `trigger` returning `{ action: 'warn', message }` adds a warning
+- `trigger` that throws is caught and warned (not fatal)
+- Async `trigger` functions are awaited
+- `trigger` block takes precedence over static rule warn (highest severity wins)
+
+### Step 2: Thread `context` and `trigger` through plugin resolution
 
 **Files to modify:**
-- `src/config/schema.ts` (`applyPlugins`) — preserve `context` functions from resolved plugins alongside files/rules
+- `src/config/schema.ts` (`applyPlugins`) — preserve `context` and `trigger` functions from resolved plugins alongside files/rules
 
-Currently `applyPlugins` merges `files[]` and `rules[]` into the config. It needs to also collect `context` functions into a new array that the hook pipeline can call.
+Currently `applyPlugins` merges `files[]` and `rules[]` into the config. It needs to also collect `context` and `trigger` functions into arrays that the hook pipeline can call.
 
-**Approach:** Add a `pluginContexts` field to the resolved config (or return it separately from `applyPlugins`). The hook pipeline receives the list of `{ name, context }` pairs.
+**Approach:** Return a `PluginExtensions` object alongside the merged config:
+
+```typescript
+interface PluginExtensions {
+    contexts: Array<{ name: string; fn: RCTPlugin['context'] }>
+    triggers: Array<{ name: string; fn: RCTPlugin['trigger'] }>
+}
+```
+
+The hook pipeline receives this alongside the config.
 
 **Tests:**
-- `applyPlugins` preserves `context` functions
-- Multiple plugins with `context` functions all collected
-- Plugin with only `context` (no files/rules) works
+- `applyPlugins` preserves `context` and `trigger` functions
+- Multiple plugins with both functions all collected
+- Plugin with only `context` or only `trigger` (no files/rules) works
+- Plugin with none of the dynamic functions still works (backwards compat)
 
 ### Step 3: Integrate into hook pipeline
 
 **Files to modify:**
-- `src/cli/hook.ts` — call plugin `context()` functions during pipeline evaluation
+- `src/cli/hook.ts` — call plugin `context()` and `trigger()` functions during pipeline evaluation
 
-**Integration point:** After `evaluateInjections()` and before `composeOutput()`. For each plugin with a `context` function, call it with the current event and input. Collect non-undefined results into the parts array.
+**Integration points:**
+
+*context:* After `evaluateInjections()` and before `composeOutput()`. For each plugin with a `context` function, call it with the current event and input. Collect non-undefined results into the parts array.
+
+*trigger:* During `evaluateRules()` phase (or immediately after). For each plugin with a `trigger` function, call it with the current event and input. If it returns a block, exit with block decision. If it returns a warn, add to warnings. Severity ordering: block > warn > undefined.
 
 **Tests:**
-- End-to-end hook test with a plugin that provides dynamic context
-- Plugin context only called for matching events
-- Plugin context errors are caught and logged, don't block pipeline
-- Plugin context output included in composed output
+- End-to-end hook test with plugin providing dynamic context
+- End-to-end hook test with plugin providing dynamic trigger (block)
+- End-to-end hook test with plugin providing dynamic trigger (warn)
+- Plugin context/trigger errors are caught and logged, don't block pipeline
+- Plugin trigger block overrides static rule warn
+- Plugin outputs included in composed output
 
 ### Step 4: Fix pre-existing issues
 
@@ -69,7 +105,7 @@ These touch the same files we're already modifying.
 
 #### 4a: Plugin error visibility (`src/config/schema.ts:110-119`)
 
-**Current:** `console.warn(`[rct] Failed to resolve plugin '${name}': ${...}`)` 
+**Current:** `console.warn(`[rct] Failed to resolve plugin '${name}': ${...}`)`
 **Fix:** Add `[rct] Warning:` prefix consistently. Check for `RCT_DEBUG` env var — if set, log full stack trace.
 
 **Test:** Verify warning format, verify debug mode shows stack trace.
@@ -91,7 +127,8 @@ These touch the same files we're already modifying.
 ### Step 5: Update tests + documentation
 
 - Run full `bun test` suite — ensure no regressions
-- Update `CLAUDE.md` architecture section to mention plugin `context` capability
+- Update `CLAUDE.md` architecture section to mention plugin `context` and `trigger` capabilities
+- Update plugin section in `README.md` with examples
 - Lint + format
 
 ## Build Sequence
@@ -120,6 +157,10 @@ export default {
         } catch {
             return undefined // tmux not available — no context
         }
+    },
+    trigger: async (event, input) => {
+        // v2: warn if Bash command conflicts with a watched pane process
+        return undefined
     }
 }
 ```

--- a/docs/superpowers/plans/2026-03-31-stream2-rct-dynamic-content.md
+++ b/docs/superpowers/plans/2026-03-31-stream2-rct-dynamic-content.md
@@ -1,0 +1,125 @@
+# Implementation Plan: Stream 2 — rct Plugin Dynamic Content Enhancement
+
+**Spec:** `docs/superpowers/specs/2026-03-31-rct-plugin-tmux-design.md` (Stream 2 section)
+**Branch:** `feat/plugin-dynamic-context`
+**Issue:** TBD (created during setup)
+**Draft PR:** TBD (created during setup)
+
+## Prerequisites
+
+- [ ] Create feature branch `feat/plugin-dynamic-context` from `main`
+- [ ] Create GitHub issue for tracking
+- [ ] Create draft PR linked to issue
+
+## Steps
+
+### Step 1: Extend `RCTPlugin` interface
+
+**Files to modify:**
+- `src/plugin/types.ts` — add optional `context` function to `RCTPlugin`
+
+```typescript
+export interface RCTPlugin extends Pick<RCTConfig, 'rules' | 'files'> {
+    name: string
+    context?: (event: HookEvent, input: RC.HookInput) => string | Promise<string> | undefined
+}
+```
+
+**Files to create:**
+- `test/plugin-dynamic-context.test.ts` — tests for the new capability
+
+**Tests (write first — TDD):**
+- Plugin with `context` function is valid
+- Plugin without `context` function still works (backwards compatible)
+- `context` returning `undefined` produces no output
+- `context` returning a string appends to additionalContext
+- `context` that throws is caught and warned (not fatal)
+- Async `context` functions are awaited
+
+### Step 2: Thread `context` through plugin resolution
+
+**Files to modify:**
+- `src/config/schema.ts` (`applyPlugins`) — preserve `context` functions from resolved plugins alongside files/rules
+
+Currently `applyPlugins` merges `files[]` and `rules[]` into the config. It needs to also collect `context` functions into a new array that the hook pipeline can call.
+
+**Approach:** Add a `pluginContexts` field to the resolved config (or return it separately from `applyPlugins`). The hook pipeline receives the list of `{ name, context }` pairs.
+
+**Tests:**
+- `applyPlugins` preserves `context` functions
+- Multiple plugins with `context` functions all collected
+- Plugin with only `context` (no files/rules) works
+
+### Step 3: Integrate into hook pipeline
+
+**Files to modify:**
+- `src/cli/hook.ts` — call plugin `context()` functions during pipeline evaluation
+
+**Integration point:** After `evaluateInjections()` and before `composeOutput()`. For each plugin with a `context` function, call it with the current event and input. Collect non-undefined results into the parts array.
+
+**Tests:**
+- End-to-end hook test with a plugin that provides dynamic context
+- Plugin context only called for matching events
+- Plugin context errors are caught and logged, don't block pipeline
+- Plugin context output included in composed output
+
+### Step 4: Fix pre-existing issues
+
+These touch the same files we're already modifying.
+
+#### 4a: Plugin error visibility (`src/config/schema.ts:110-119`)
+
+**Current:** `console.warn(`[rct] Failed to resolve plugin '${name}': ${...}`)` 
+**Fix:** Add `[rct] Warning:` prefix consistently. Check for `RCT_DEBUG` env var — if set, log full stack trace.
+
+**Test:** Verify warning format, verify debug mode shows stack trace.
+
+#### 4b: Silent file reference failures (`src/engine/injections.ts:50-78`)
+
+**Current:** `if (!resolved) continue` — no warning.
+**Fix:** Add `console.warn(`[rct] Warning: FileRef '${ref}' did not resolve — skipping injection`)`.
+
+**Test:** Verify warning emitted for unresolvable refs.
+
+#### 4c: Unused `staleCheck.format` parameter (`src/config/schema.ts`)
+
+**Current:** `format?: string` accepted but never used.
+**Fix:** Remove `format` from `StaleCheckConfig` type in `src/config/types.ts`. Check if any test or config references it.
+
+**Test:** Verify type no longer accepts `format`.
+
+### Step 5: Update tests + documentation
+
+- Run full `bun test` suite — ensure no regressions
+- Update `CLAUDE.md` architecture section to mention plugin `context` capability
+- Lint + format
+
+## Build Sequence
+
+```
+Step 1 (interface) → Step 2 (resolution) → Step 3 (pipeline integration)
+                                          → Step 4 (pre-existing fixes, parallel with Step 3)
+                                          → Step 5 (tests + docs)
+```
+
+Steps 3 and 4 can run in parallel — they touch different files (hook.ts vs schema.ts/injections.ts/types.ts).
+
+## Touch Point with Stream 1
+
+After this lands, a follow-up PR updates `rct-plugin-tmux/src/index.ts`:
+
+```typescript
+import { listPanes, formatLayoutSummary } from './lib/tmux'
+
+export default {
+    name: 'tmux',
+    context: async (event) => {
+        if (event !== 'SessionStart') return undefined
+        try {
+            return formatLayoutSummary(await listPanes())
+        } catch {
+            return undefined // tmux not available — no context
+        }
+    }
+}
+```

--- a/rct.config.schema.json
+++ b/rct.config.schema.json
@@ -163,10 +163,6 @@
                         "wrapTag": {
                             "type": "string",
                             "description": "Tag name wrapping the content"
-                        },
-                        "format": {
-                            "type": "string",
-                            "description": "Date format string"
                         }
                     }
                 },

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -21,7 +21,6 @@ import {
 } from '#test/runner'
 import { composeOutput } from '#engine/compose'
 import type { HookEvent, TestConfig, LangTestConfig } from '#config/types'
-import type { PluginExtensions } from '#config/schema'
 import type { PluginHookInput } from '#plugin/types'
 
 const SYNC_EVENTS: HookEvent[] = ['SessionStart', 'Setup']

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -31,21 +31,27 @@ async function withTimeout<T>(
     ms: number,
     label: string,
 ): Promise<T | undefined> {
+    const TIMEOUT_SENTINEL = Symbol('timeout')
+    let timer: ReturnType<typeof setTimeout>
     try {
-        return await Promise.race([
+        const result = await Promise.race([
             Promise.resolve(fn()),
-            new Promise<never>((_, reject) =>
-                setTimeout(
-                    () => reject(new Error(`${label} timed out after ${ms}ms`)),
-                    ms,
-                ),
-            ),
+            new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+                timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), ms)
+            }),
         ])
+        if (result === TIMEOUT_SENTINEL) {
+            console.warn(`[rct] Warning: ${label} timed out after ${ms}ms`)
+            return undefined
+        }
+        return result as T
     } catch (err) {
         console.warn(
             `[rct] Warning: ${label}: ${err instanceof Error ? err.message : err}`,
         )
         return undefined
+    } finally {
+        clearTimeout(timer!)
     }
 }
 
@@ -54,6 +60,7 @@ export { withTimeout }
 async function main(eventArg?: string) {
     const event = (eventArg ?? process.argv[2]) as HookEvent
     if (!event) {
+        console.error('[rct] Error: No hook event specified. Usage: rct hook <HookEvent>')
         process.exit(1)
     }
 

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -32,7 +32,7 @@ async function main(eventArg?: string) {
 
     const config = await loadConfig()
     const validated = validateConfig(config)
-    const withPlugins = await applyPlugins(validated)
+    const { config: withPlugins, extensions } = await applyPlugins(validated)
     const desugared = desugarFileInjections(withPlugins)
     const registry = buildFileRegistry(desugared.files ?? [])
     const globals = desugared.globals

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -21,8 +21,36 @@ import {
 } from '#test/runner'
 import { composeOutput } from '#engine/compose'
 import type { HookEvent, TestConfig, LangTestConfig } from '#config/types'
+import type { PluginExtensions } from '#config/schema'
+import type { PluginHookInput } from '#plugin/types'
 
 const SYNC_EVENTS: HookEvent[] = ['SessionStart', 'Setup']
+const PLUGIN_TIMEOUT_MS = 5000
+
+async function withTimeout<T>(
+    fn: () => T | Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T | undefined> {
+    try {
+        return await Promise.race([
+            Promise.resolve(fn()),
+            new Promise<never>((_, reject) =>
+                setTimeout(
+                    () => reject(new Error(`${label} timed out after ${ms}ms`)),
+                    ms,
+                ),
+            ),
+        ])
+    } catch (err) {
+        console.warn(
+            `[rct] Warning: ${label}: ${err instanceof Error ? err.message : err}`,
+        )
+        return undefined
+    }
+}
+
+export { withTimeout }
 
 async function main(eventArg?: string) {
     const event = (eventArg ?? process.argv[2]) as HookEvent
@@ -73,7 +101,36 @@ async function main(eventArg?: string) {
         payload,
     )
 
-    // If block, output and exit
+    // Evaluate plugin triggers
+    const pluginInput: PluginHookInput = { toolName, payload }
+    const pluginWarnMessages: string[] = []
+
+    for (const { name, fn } of extensions.triggers) {
+        const result = await withTimeout(
+            () => fn(event, pluginInput),
+            PLUGIN_TIMEOUT_MS,
+            `plugin '${name}' trigger`,
+        )
+        if (result?.action === 'block') {
+            const output = composeOutput({
+                event,
+                blockResult: { message: result.message },
+                warnMessages: [],
+                injectionResults: [],
+                metaResult: null,
+                langResult: null,
+                testResult: null,
+                globals,
+            })
+            console.log(output)
+            process.exit(2)
+        }
+        if (result?.action === 'warn') {
+            pluginWarnMessages.push(result.message)
+        }
+    }
+
+    // If static rule blocks, output and exit
     if (ruleResult?.action === 'block') {
         const output = composeOutput({
             event,
@@ -99,9 +156,24 @@ async function main(eventArg?: string) {
         globals,
     )
 
-    // Warn messages
-    const warnMessages =
-        ruleResult?.action === 'warn' ? ruleResult.messages : []
+    // Evaluate plugin contexts
+    const pluginContextResults: string[] = []
+    for (const { name, fn } of extensions.contexts) {
+        const result = await withTimeout(
+            () => fn(event, pluginInput),
+            PLUGIN_TIMEOUT_MS,
+            `plugin '${name}' context`,
+        )
+        if (result !== undefined) {
+            pluginContextResults.push(result)
+        }
+    }
+
+    // Warn messages (static rules + plugin triggers)
+    const warnMessages = [
+        ...(ruleResult?.action === 'warn' ? ruleResult.messages : []),
+        ...pluginWarnMessages,
+    ]
 
     // Meta
     let metaResult: string | null = null
@@ -212,6 +284,7 @@ async function main(eventArg?: string) {
         blockResult: null,
         warnMessages,
         injectionResults,
+        pluginContextResults,
         metaResult,
         langResult,
         testResult,

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -166,14 +166,19 @@ async function main(eventArg?: string) {
 
     // Evaluate plugin contexts
     const pluginContextResults: string[] = []
-    for (const { name, fn } of extensions.contexts) {
-        const result = await withTimeout(
-            () => fn(event, pluginInput),
-            PLUGIN_TIMEOUT_MS,
-            `plugin '${name}' context`,
+    if (extensions.contexts.length > 0) {
+        const contextPromises = extensions.contexts.map(({ name, fn }) =>
+            withTimeout(
+                () => fn(event, pluginInput),
+                PLUGIN_TIMEOUT_MS,
+                `plugin '${name}' context`,
+            ),
         )
-        if (result !== undefined) {
-            pluginContextResults.push(result)
+        const settledContexts = await Promise.allSettled(contextPromises)
+        for (const settled of settledContexts) {
+            if (settled.status === 'fulfilled' && settled.value !== undefined) {
+                pluginContextResults.push(settled.value)
+            }
         }
     }
 

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -32,7 +32,7 @@ async function withTimeout<T>(
     label: string,
 ): Promise<T | undefined> {
     const TIMEOUT_SENTINEL = Symbol('timeout')
-    let timer: ReturnType<typeof setTimeout>
+    let timer: ReturnType<typeof setTimeout> | undefined
     try {
         const result = await Promise.race([
             Promise.resolve(fn()),
@@ -51,7 +51,7 @@ async function withTimeout<T>(
         )
         return undefined
     } finally {
-        clearTimeout(timer!)
+        if (timer !== undefined) clearTimeout(timer)
     }
 }
 
@@ -60,7 +60,9 @@ export { withTimeout }
 async function main(eventArg?: string) {
     const event = (eventArg ?? process.argv[2]) as HookEvent
     if (!event) {
-        console.error('[rct] Error: No hook event specified. Usage: rct hook <HookEvent>')
+        console.error(
+            '[rct] Error: No hook event specified. Usage: rct hook <HookEvent>',
+        )
         process.exit(1)
     }
 
@@ -99,15 +101,7 @@ async function main(eventArg?: string) {
         }
     }
 
-    // Evaluate rules
-    const ruleResult = evaluateRules(
-        desugared.rules ?? [],
-        event,
-        toolName,
-        payload,
-    )
-
-    // Evaluate plugin triggers
+    // Evaluate plugin triggers (before static rules — early exit on block)
     const pluginInput: PluginHookInput = { toolName, payload }
     const pluginWarnMessages: string[] = []
 
@@ -135,6 +129,14 @@ async function main(eventArg?: string) {
             pluginWarnMessages.push(result.message)
         }
     }
+
+    // Evaluate static rules
+    const ruleResult = evaluateRules(
+        desugared.rules ?? [],
+        event,
+        toolName,
+        payload,
+    )
 
     // If static rule blocks, output and exit
     if (ruleResult?.action === 'block') {

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -34,12 +34,11 @@ async function withTimeout<T>(
     const TIMEOUT_SENTINEL = Symbol('timeout')
     let timer: ReturnType<typeof setTimeout> | undefined
     try {
-        const result = await Promise.race([
-            Promise.resolve(fn()),
-            new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
-                timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), ms)
-            }),
-        ])
+        const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+            timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), ms)
+        })
+        const workPromise = Promise.resolve().then(fn)
+        const result = await Promise.race([workPromise, timeoutPromise])
         if (result === TIMEOUT_SENTINEL) {
             console.warn(`[rct] Warning: ${label} timed out after ${ms}ms`)
             return undefined

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -403,7 +403,7 @@ export default async function initializeRCT(args: string[] = []) {
 
     // Apply plugins and desugar to get full config for mergeSettings
     const validated = validateConfig(config)
-    const withPlugins = await applyPlugins(validated)
+    const { config: withPlugins } = await applyPlugins(validated)
     const fullConfig = desugarFileInjections(withPlugins)
 
     const settingsPath = fs.resolve(['.claude', 'settings.json'], { root })

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -83,7 +83,7 @@ export default async function updateRCT(_args: string[] = []) {
 
     // Validate and resolve for settings
     const validated = validateConfig(configWithoutDerived as RCTConfig)
-    const withPlugins = await applyPlugins(validated)
+    const { config: withPlugins } = await applyPlugins(validated)
     const desugared = desugarFileInjections(withPlugins)
 
     // Write config with _derived

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -131,8 +131,11 @@ export async function applyPlugins(
                 extensions.triggers.push({ name, fn: plugin.trigger })
         } catch (err) {
             console.warn(
-                `[rct] Failed to resolve plugin '${name}': ${err instanceof Error ? err.message : err}`,
+                `[rct] Warning: Failed to resolve plugin '${name}': ${err instanceof Error ? err.message : err}`,
             )
+            if (process.env.RCT_DEBUG && err instanceof Error && err.stack) {
+                console.warn(err.stack)
+            }
         }
     }
 
@@ -199,7 +202,7 @@ export function desugarFileInjections(
 
 export function applyStaleCheck(
     content: string,
-    staleConfig: { dateTag: string; wrapTag: string; format?: string },
+    staleConfig: { dateTag: string; wrapTag: string },
     today: string,
 ): string {
     const dateRegex = new RegExp(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -122,18 +122,29 @@ export async function applyPlugins(
     for (const name of pluginNames) {
         try {
             const { plugin } = await resolvePlugin(name)
+            const displayName = typeof plugin.name === 'string' ? plugin.name : String(name)
             if (plugin.files) mergedFiles.push(...plugin.files)
             if (plugin.rules) mergedRules.push(...plugin.rules)
-            if (plugin.context)
+            if (typeof plugin.context === 'function') {
                 extensions.contexts.push({
-                    name: plugin.name ?? name,
+                    name: displayName,
                     fn: plugin.context,
                 })
-            if (plugin.trigger)
+            } else if (plugin.context) {
+                console.warn(
+                    `[rct] Warning: Plugin '${displayName}' has a non-function 'context' property; ignoring.`,
+                )
+            }
+            if (typeof plugin.trigger === 'function') {
                 extensions.triggers.push({
-                    name: plugin.name ?? name,
+                    name: displayName,
                     fn: plugin.trigger,
                 })
+            } else if (plugin.trigger) {
+                console.warn(
+                    `[rct] Warning: Plugin '${displayName}' has a non-function 'trigger' property; ignoring.`,
+                )
+            }
         } catch (err) {
             console.warn(
                 `[rct] Warning: Failed to resolve plugin '${name}': ${err instanceof Error ? err.message : err}`,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -113,8 +113,7 @@ export async function applyPlugins(
 ): Promise<ApplyPluginsResult> {
     const extensions: PluginExtensions = { contexts: [], triggers: [] }
     const pluginNames = config.globals.plugins ?? []
-    if (pluginNames.length === 0)
-        return { config, extensions }
+    if (pluginNames.length === 0) return { config, extensions }
 
     const mergedFiles: FileEntry[] = [...(config.files ?? [])]
     const mergedRules: RuleEntry[] = [...(config.rules ?? [])]
@@ -126,9 +125,15 @@ export async function applyPlugins(
             if (plugin.files) mergedFiles.push(...plugin.files)
             if (plugin.rules) mergedRules.push(...plugin.rules)
             if (plugin.context)
-                extensions.contexts.push({ name, fn: plugin.context })
+                extensions.contexts.push({
+                    name: plugin.name ?? name,
+                    fn: plugin.context,
+                })
             if (plugin.trigger)
-                extensions.triggers.push({ name, fn: plugin.trigger })
+                extensions.triggers.push({
+                    name: plugin.name ?? name,
+                    fn: plugin.trigger,
+                })
         } catch (err) {
             console.warn(
                 `[rct] Warning: Failed to resolve plugin '${name}': ${err instanceof Error ? err.message : err}`,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,6 @@
 import { fs } from '#util/fs'
 import { resolvePlugin } from '#plugin/resolve'
+import type { RCTPlugin } from '#plugin/types'
 import type {
     RCTConfig,
     GlobalsConfig,
@@ -10,6 +11,16 @@ import type {
     FileEntry,
     RuleEntry,
 } from './types'
+
+export interface PluginExtensions {
+    contexts: Array<{ name: string; fn: NonNullable<RCTPlugin['context']> }>
+    triggers: Array<{ name: string; fn: NonNullable<RCTPlugin['trigger']> }>
+}
+
+export interface ApplyPluginsResult {
+    config: ValidatedConfig
+    extensions: PluginExtensions
+}
 
 export type ValidatedConfig = { globals: Required<GlobalsConfig> } & RCTConfig
 
@@ -99,9 +110,11 @@ export function validateConfig(config: RCTConfig): ValidatedConfig {
 
 export async function applyPlugins(
     config: ValidatedConfig,
-): Promise<ValidatedConfig> {
+): Promise<ApplyPluginsResult> {
+    const extensions: PluginExtensions = { contexts: [], triggers: [] }
     const pluginNames = config.globals.plugins ?? []
-    if (pluginNames.length === 0) return config
+    if (pluginNames.length === 0)
+        return { config, extensions }
 
     const mergedFiles: FileEntry[] = [...(config.files ?? [])]
     const mergedRules: RuleEntry[] = [...(config.rules ?? [])]
@@ -112,6 +125,10 @@ export async function applyPlugins(
             const { plugin } = await resolvePlugin(name)
             if (plugin.files) mergedFiles.push(...plugin.files)
             if (plugin.rules) mergedRules.push(...plugin.rules)
+            if (plugin.context)
+                extensions.contexts.push({ name, fn: plugin.context })
+            if (plugin.trigger)
+                extensions.triggers.push({ name, fn: plugin.trigger })
         } catch (err) {
             console.warn(
                 `[rct] Failed to resolve plugin '${name}': ${err instanceof Error ? err.message : err}`,
@@ -119,11 +136,13 @@ export async function applyPlugins(
         }
     }
 
-    return {
+    const merged: ValidatedConfig = {
         ...config,
         files: mergedFiles,
         rules: mergedRules.length > hadRules ? mergedRules : config.rules,
     }
+
+    return { config: merged, extensions }
 }
 
 export function desugarFileInjections(

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -77,8 +77,6 @@ export interface FileEntry extends MetaFileEntry {
         dateTag: string
         /** Tag name wrapping the content */
         wrapTag: string
-        /** Date format string */
-        format?: string
     }
     /** Associated meta-files */
     metaFiles?: MetaFileEntry[]

--- a/src/engine/compose.ts
+++ b/src/engine/compose.ts
@@ -6,6 +6,7 @@ export interface ComposeInput {
     blockResult: { message: string } | null
     warnMessages: string[]
     injectionResults: string[]
+    pluginContextResults?: string[]
     metaResult: string | null
     langResult: string | null
     testResult: string | null
@@ -43,6 +44,7 @@ export function composeOutput(input: ComposeInput): string {
         blockResult,
         warnMessages,
         injectionResults,
+        pluginContextResults = [],
         metaResult,
         langResult,
         testResult,
@@ -63,6 +65,7 @@ export function composeOutput(input: ComposeInput): string {
     // Collect all context strings
     const parts: string[] = [
         ...injectionResults,
+        ...pluginContextResults,
         ...warnMessages,
         ...(metaResult ? [metaResult] : []),
         ...(langResult ? [langResult] : []),

--- a/src/engine/injections.ts
+++ b/src/engine/injections.ts
@@ -49,7 +49,12 @@ export function evaluateInjections(
 
         for (const ref of injection.inject) {
             const resolved = registry.getRef(ref)
-            if (!resolved) continue
+            if (!resolved) {
+                console.warn(
+                    `[rct] Warning: FileRef '${ref}' did not resolve — skipping injection`,
+                )
+                continue
+            }
 
             const { file, useBrief } = resolved
             const shouldUseBrief =

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
     desugarFileInjections,
     applyPlugins,
 } from '#config/schema'
+export type { PluginExtensions, ApplyPluginsResult } from '#config/schema'
 
 /** Build the alias-to-content Map used by injections and meta. Composable for custom pipelines. */
 export { buildFileRegistry } from '#config/files'

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,11 @@ export { normalize, minify, condense } from '#util/general'
 
 // Plugin
 
-export type { RCTPlugin } from '#plugin/types'
+export type {
+    RCTPlugin,
+    PluginHookInput,
+    PluginTriggerResult,
+} from '#plugin/types'
 
 /** Registry mapping plugin names to their RCTPlugin instances. */
 export { default as pluginRegistry } from '#plugin/index'

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,5 +1,28 @@
-import { RCTConfig } from '#config/types'
+import type { RCTConfig, HookEvent } from '#config/types'
+
+/** Result from a plugin's dynamic trigger function. */
+export interface PluginTriggerResult {
+    action: 'block' | 'warn'
+    message: string
+}
+
+/** Input passed to plugin context/trigger functions — matches what the hook pipeline actually has. */
+export interface PluginHookInput {
+    toolName?: string
+    payload: Record<string, unknown>
+}
 
 export interface RCTPlugin extends Pick<RCTConfig, 'rules' | 'files'> {
     name: string
+    context?: (
+        event: HookEvent,
+        input: PluginHookInput,
+    ) => string | undefined | Promise<string | undefined>
+    trigger?: (
+        event: HookEvent,
+        input: PluginHookInput,
+    ) =>
+        | PluginTriggerResult
+        | undefined
+        | Promise<PluginTriggerResult | undefined>
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -98,10 +98,7 @@ describe('RCT Config Types', () => {
         const entry: FileEntry = {
             path: 'src/index.ts',
             alias: 'main',
-            staleCheck: {
-                dateTag: 'last-updated',
-                wrapTag: 'file-content',
-            },
+            staleCheck: { dateTag: 'last-updated', wrapTag: 'file-content' },
             metaFiles: [{ path: 'meta.md', alias: 'meta' }],
         }
         expect(entry.staleCheck?.dateTag).toBe('last-updated')

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -101,7 +101,6 @@ describe('RCT Config Types', () => {
             staleCheck: {
                 dateTag: 'last-updated',
                 wrapTag: 'file-content',
-                format: 'YYYY-MM-DD',
             },
             metaFiles: [{ path: 'meta.md', alias: 'meta' }],
         }

--- a/test/fixtures/plugin-project-throwing/plugins/throwing-context.ts
+++ b/test/fixtures/plugin-project-throwing/plugins/throwing-context.ts
@@ -1,0 +1,6 @@
+export default {
+    name: 'throwing-context',
+    context() {
+        throw new Error('context exploded in integration test')
+    },
+}

--- a/test/fixtures/plugin-project-throwing/rct.config.json
+++ b/test/fixtures/plugin-project-throwing/rct.config.json
@@ -1,0 +1,6 @@
+{
+    "globals": {
+        "format": "xml",
+        "plugins": ["./plugins/throwing-context.ts"]
+    }
+}

--- a/test/fixtures/plugin-project/plugins/block-trigger.ts
+++ b/test/fixtures/plugin-project/plugins/block-trigger.ts
@@ -1,0 +1,12 @@
+export default {
+    name: 'block-trigger',
+    trigger(_event: string, input: { toolName?: string }) {
+        if (input.toolName === 'BlockedTool') {
+            return {
+                action: 'block' as const,
+                message: 'BlockedTool is not allowed by plugin',
+            }
+        }
+        return undefined
+    },
+}

--- a/test/fixtures/plugin-project/plugins/context-plugin.ts
+++ b/test/fixtures/plugin-project/plugins/context-plugin.ts
@@ -1,0 +1,9 @@
+export default {
+    name: 'context-plugin',
+    context(event: string) {
+        if (event === 'SessionStart') {
+            return '<dynamic-context>tmux layout data</dynamic-context>'
+        }
+        return undefined
+    },
+}

--- a/test/fixtures/plugin-project/plugins/throwing-context.ts
+++ b/test/fixtures/plugin-project/plugins/throwing-context.ts
@@ -1,0 +1,6 @@
+export default {
+    name: 'throwing-context',
+    context() {
+        throw new Error('context exploded in integration test')
+    },
+}

--- a/test/fixtures/plugin-project/plugins/warn-trigger.ts
+++ b/test/fixtures/plugin-project/plugins/warn-trigger.ts
@@ -1,0 +1,12 @@
+export default {
+    name: 'warn-trigger',
+    trigger(_event: string, input: { toolName?: string }) {
+        if (input.toolName === 'WarnTool') {
+            return {
+                action: 'warn' as const,
+                message: 'WarnTool requires caution',
+            }
+        }
+        return undefined
+    },
+}

--- a/test/fixtures/plugin-project/rct.config.json
+++ b/test/fixtures/plugin-project/rct.config.json
@@ -1,0 +1,10 @@
+{
+    "globals": {
+        "format": "xml",
+        "plugins": [
+            "./plugins/block-trigger.ts",
+            "./plugins/warn-trigger.ts",
+            "./plugins/context-plugin.ts"
+        ]
+    }
+}

--- a/test/hook-plugin.test.ts
+++ b/test/hook-plugin.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'bun:test'
+import { spawnSync } from 'child_process'
+import path from 'path'
+
+const INDEX_PATH = path.resolve(__dirname, '../src/cli/index.ts')
+const FIXTURE_DIR = path.resolve(__dirname, 'fixtures/plugin-project')
+const THROWING_FIXTURE_DIR = path.resolve(
+    __dirname,
+    'fixtures/plugin-project-throwing',
+)
+
+function runHook(
+    event: string,
+    fixtureDir: string,
+    stdin?: string,
+    env?: Record<string, string>,
+) {
+    const result = spawnSync('bun', ['run', INDEX_PATH, 'hook', event], {
+        cwd: fixtureDir,
+        env: {
+            ...process.env,
+            CLAUDE_PROJECT_DIR: fixtureDir,
+            ...env,
+        },
+        input: stdin,
+        encoding: 'utf-8',
+        timeout: 15_000,
+    })
+    return {
+        stdout: result.stdout?.trim() ?? '',
+        stderr: result.stderr?.trim() ?? '',
+        exitCode: result.status ?? 1,
+    }
+}
+
+describe('hook pipeline — plugin trigger integration', () => {
+    it('plugin trigger blocks with exit code 2 when tool matches', () => {
+        const payload = JSON.stringify({
+            tool_name: 'BlockedTool',
+            tool_input: {},
+        })
+        const result = runHook('PreToolUse', FIXTURE_DIR, payload)
+        expect(result.exitCode).toBe(2)
+        const parsed = JSON.parse(result.stdout)
+        expect(parsed.decision).toBe('block')
+        expect(parsed.reason).toContain('BlockedTool is not allowed by plugin')
+    })
+
+    it('plugin trigger does not block when tool does not match', () => {
+        const payload = JSON.stringify({
+            tool_name: 'Read',
+            tool_input: {},
+        })
+        const result = runHook('PreToolUse', FIXTURE_DIR, payload)
+        expect(result.exitCode).toBe(0)
+    })
+
+    it('plugin trigger warns without blocking when tool matches warn condition', () => {
+        const payload = JSON.stringify({
+            tool_name: 'WarnTool',
+            tool_input: {},
+        })
+        const result = runHook('PreToolUse', FIXTURE_DIR, payload)
+        expect(result.exitCode).toBe(0)
+        // Warn message is included in additionalContext (not a block response)
+        const parsed = JSON.parse(result.stdout)
+        const ctx = parsed.hookSpecificOutput?.additionalContext ?? ''
+        expect(ctx).toContain('WarnTool requires caution')
+    })
+})
+
+describe('hook pipeline — plugin context integration', () => {
+    it('plugin context injects dynamic output on SessionStart', () => {
+        const result = runHook('SessionStart', FIXTURE_DIR)
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout).toBeTruthy()
+        const parsed = JSON.parse(result.stdout)
+        expect(parsed.hookSpecificOutput).toBeDefined()
+        expect(parsed.hookSpecificOutput.hookEventName).toBe('SessionStart')
+        const ctx = parsed.hookSpecificOutput.additionalContext ?? ''
+        expect(ctx).toContain('tmux layout data')
+    })
+
+    it('plugin context does not inject on non-matching events', () => {
+        const payload = JSON.stringify({ tool_name: 'Read', tool_input: {} })
+        const result = runHook('PostToolUse', FIXTURE_DIR, payload)
+        expect(result.exitCode).toBe(0)
+        // context-plugin only returns content on SessionStart, so no tmux content
+        if (result.stdout) {
+            const parsed = JSON.parse(result.stdout)
+            const ctx = parsed.hookSpecificOutput?.additionalContext ?? ''
+            expect(ctx).not.toContain('tmux layout data')
+        }
+    })
+})
+
+describe('hook pipeline — plugin error isolation', () => {
+    it('throwing context does not break the pipeline', () => {
+        // Use a fixture that includes the throwing-context plugin
+        const result = runHook('SessionStart', THROWING_FIXTURE_DIR)
+        // Should still exit 0 despite the throwing plugin
+        expect(result.exitCode).toBe(0)
+    })
+})

--- a/test/injections.test.ts
+++ b/test/injections.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test'
+import { describe, test, expect, spyOn } from 'bun:test'
 import { evaluateInjections } from '../src/engine/injections'
 import type { InjectionEntry, GlobalsConfig } from '../src/config/types'
 import type { FileRegistry, ReferenceFile } from '../src/types'
@@ -300,5 +300,29 @@ describe('evaluateInjections', () => {
         expect(result).toHaveLength(1)
         expect(result[0]).not.toContain('<stale-scope')
         expect(result[0]).toBe(freshContent)
+    })
+})
+
+describe('evaluateInjections — unresolved FileRef warning', () => {
+    test('warns and skips when FileRef does not resolve', () => {
+        const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+        const registry = makeRegistry([])
+        const injection: InjectionEntry = {
+            on: 'SessionStart',
+            inject: ['nonexistent'],
+        }
+        const result = evaluateInjections(
+            [injection],
+            'SessionStart',
+            undefined,
+            {},
+            registry,
+            defaultGlobals,
+        )
+        expect(result).toHaveLength(0)
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining("FileRef 'nonexistent' did not resolve"),
+        )
+        warnSpy.mockRestore()
     })
 })

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -173,15 +173,17 @@ describe('RCTPlugin trigger function', () => {
         const origWarn = console.warn
         console.warn = (...args: unknown[]) => warns.push(String(args[0]))
 
-        const result = await withTimeout(
-            () => plugin.trigger!('PreToolUse', { payload: {} }),
-            5000,
-            'test-trigger',
-        )
-
-        console.warn = origWarn
-        expect(result).toBeUndefined()
-        expect(warns.some((w) => w.includes('trigger exploded'))).toBe(true)
+        try {
+            const result = await withTimeout(
+                () => plugin.trigger!('PreToolUse', { payload: {} }),
+                5000,
+                'test-trigger',
+            )
+            expect(result).toBeUndefined()
+            expect(warns.some((w) => w.includes('trigger exploded'))).toBe(true)
+        } finally {
+            console.warn = origWarn
+        }
     })
 
     test('async trigger functions are awaited', async () => {

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -44,17 +44,27 @@ describe('RCTPlugin context function', () => {
         expect(result).toBe('<tmux>pane layout here</tmux>')
     })
 
-    test('context that throws is caught and warned (not fatal)', async () => {
+    test('context that throws is caught by withTimeout (not fatal)', async () => {
         const plugin: RCTPlugin = {
             name: 'throwing-context',
             context: () => {
                 throw new Error('context exploded')
             },
         }
-        // The function itself throws — the pipeline must catch it
-        expect(() => plugin.context!('SessionStart', { payload: {} })).toThrow(
-            'context exploded',
+        // withTimeout catches the error and returns undefined with a warning
+        const warns: string[] = []
+        const origWarn = console.warn
+        console.warn = (...args: unknown[]) => warns.push(String(args[0]))
+
+        const result = await withTimeout(
+            () => plugin.context!('SessionStart', { payload: {} }),
+            5000,
+            'test-context',
         )
+
+        console.warn = origWarn
+        expect(result).toBeUndefined()
+        expect(warns.some((w) => w.includes('context exploded'))).toBe(true)
     })
 
     test('async context functions are awaited', async () => {
@@ -148,16 +158,27 @@ describe('RCTPlugin trigger function', () => {
         expect(result.message).toBe('Be careful with this tool')
     })
 
-    test('trigger that throws is caught and warned (not fatal)', () => {
+    test('trigger that throws is caught by withTimeout (not fatal)', async () => {
         const plugin: RCTPlugin = {
             name: 'throwing-trigger',
             trigger: () => {
                 throw new Error('trigger exploded')
             },
         }
-        expect(() => plugin.trigger!('PreToolUse', { payload: {} })).toThrow(
-            'trigger exploded',
+        // withTimeout catches the error and returns undefined with a warning
+        const warns: string[] = []
+        const origWarn = console.warn
+        console.warn = (...args: unknown[]) => warns.push(String(args[0]))
+
+        const result = await withTimeout(
+            () => plugin.trigger!('PreToolUse', { payload: {} }),
+            5000,
+            'test-trigger',
         )
+
+        console.warn = origWarn
+        expect(result).toBeUndefined()
+        expect(warns.some((w) => w.includes('trigger exploded'))).toBe(true)
     })
 
     test('async trigger functions are awaited', async () => {

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -54,17 +54,20 @@ describe('RCTPlugin context function', () => {
         // withTimeout catches the error and returns undefined with a warning
         const warns: string[] = []
         const origWarn = console.warn
-        console.warn = (...args: unknown[]) => warns.push(String(args[0]))
+        try {
+            console.warn = (...args: unknown[]) => warns.push(String(args[0]))
 
-        const result = await withTimeout(
-            () => plugin.context!('SessionStart', { payload: {} }),
-            5000,
-            'test-context',
-        )
+            const result = await withTimeout(
+                () => plugin.context!('SessionStart', { payload: {} }),
+                5000,
+                'test-context',
+            )
 
-        console.warn = origWarn
-        expect(result).toBeUndefined()
-        expect(warns.some((w) => w.includes('context exploded'))).toBe(true)
+            expect(result).toBeUndefined()
+            expect(warns.some((w) => w.includes('context exploded'))).toBe(true)
+        } finally {
+            console.warn = origWarn
+        }
     })
 
     test('async context functions are awaited', async () => {

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import type {
     RCTPlugin,
     PluginHookInput,
@@ -6,7 +6,6 @@ import type {
 } from '../src/plugin/types'
 import type { HookEvent } from '../src/config/types'
 import { applyPlugins, type ValidatedConfig } from '../src/config/schema'
-import type { PluginExtensions } from '../src/config/schema'
 import { composeOutput } from '../src/engine/compose'
 import { withTimeout } from '../src/cli/hook'
 
@@ -23,11 +22,7 @@ describe('RCTPlugin context function', () => {
     })
 
     test('plugin without context function still works (backwards compatible)', () => {
-        const plugin: RCTPlugin = {
-            name: 'no-context',
-            files: [],
-            rules: [],
-        }
+        const plugin: RCTPlugin = { name: 'no-context', files: [], rules: [] }
         expect(plugin.context).toBeUndefined()
     })
 
@@ -36,9 +31,7 @@ describe('RCTPlugin context function', () => {
             name: 'undefined-context',
             context: () => undefined,
         }
-        const result = plugin.context!('SessionStart', {
-            payload: {},
-        })
+        const result = plugin.context!('SessionStart', { payload: {} })
         expect(result).toBeUndefined()
     })
 
@@ -47,9 +40,7 @@ describe('RCTPlugin context function', () => {
             name: 'string-context',
             context: () => '<tmux>pane layout here</tmux>',
         }
-        const result = plugin.context!('SessionStart', {
-            payload: {},
-        })
+        const result = plugin.context!('SessionStart', { payload: {} })
         expect(result).toBe('<tmux>pane layout here</tmux>')
     })
 
@@ -61,9 +52,9 @@ describe('RCTPlugin context function', () => {
             },
         }
         // The function itself throws — the pipeline must catch it
-        expect(() =>
-            plugin.context!('SessionStart', { payload: {} }),
-        ).toThrow('context exploded')
+        expect(() => plugin.context!('SessionStart', { payload: {} })).toThrow(
+            'context exploded',
+        )
     })
 
     test('async context functions are awaited', async () => {
@@ -73,9 +64,7 @@ describe('RCTPlugin context function', () => {
                 return 'async result'
             },
         }
-        const result = await plugin.context!('SessionStart', {
-            payload: {},
-        })
+        const result = await plugin.context!('SessionStart', { payload: {} })
         expect(result).toBe('async result')
     })
 
@@ -115,9 +104,7 @@ describe('RCTPlugin trigger function', () => {
     })
 
     test('plugin without trigger function still works', () => {
-        const plugin: RCTPlugin = {
-            name: 'no-trigger',
-        }
+        const plugin: RCTPlugin = { name: 'no-trigger' }
         expect(plugin.trigger).toBeUndefined()
     })
 
@@ -126,9 +113,7 @@ describe('RCTPlugin trigger function', () => {
             name: 'undefined-trigger',
             trigger: () => undefined,
         }
-        const result = plugin.trigger!('PreToolUse', {
-            payload: {},
-        })
+        const result = plugin.trigger!('PreToolUse', { payload: {} })
         expect(result).toBeUndefined()
     })
 
@@ -170,9 +155,9 @@ describe('RCTPlugin trigger function', () => {
                 throw new Error('trigger exploded')
             },
         }
-        expect(() =>
-            plugin.trigger!('PreToolUse', { payload: {} }),
-        ).toThrow('trigger exploded')
+        expect(() => plugin.trigger!('PreToolUse', { payload: {} })).toThrow(
+            'trigger exploded',
+        )
     })
 
     test('async trigger functions are awaited', async () => {
@@ -182,13 +167,8 @@ describe('RCTPlugin trigger function', () => {
                 return { action: 'warn' as const, message: 'async warning' }
             },
         }
-        const result = await plugin.trigger!('PreToolUse', {
-            payload: {},
-        })
-        expect(result).toEqual({
-            action: 'warn',
-            message: 'async warning',
-        })
+        const result = await plugin.trigger!('PreToolUse', { payload: {} })
+        expect(result).toEqual({ action: 'warn', message: 'async warning' })
     })
 
     test('trigger receives event and input', () => {
@@ -309,7 +289,11 @@ describe('withTimeout', () => {
     })
 
     test('returns value from async function', async () => {
-        const result = await withTimeout(async () => 'async hello', 5000, 'test')
+        const result = await withTimeout(
+            async () => 'async hello',
+            5000,
+            'test',
+        )
         expect(result).toBe('async hello')
     })
 
@@ -328,7 +312,9 @@ describe('withTimeout', () => {
 
         console.warn = origWarn
         expect(result).toBeUndefined()
-        expect(warns.some((w) => w.includes('test-fn') && w.includes('boom'))).toBe(true)
+        expect(
+            warns.some((w) => w.includes('test-fn') && w.includes('boom')),
+        ).toBe(true)
     })
 
     test('returns undefined on timeout', async () => {
@@ -337,14 +323,19 @@ describe('withTimeout', () => {
         console.warn = (...args: unknown[]) => warns.push(String(args[0]))
 
         const result = await withTimeout(
-            () => new Promise<string>((resolve) => setTimeout(() => resolve('late'), 10000)),
+            () =>
+                new Promise<string>((resolve) =>
+                    setTimeout(() => resolve('late'), 10000),
+                ),
             50,
             'slow-fn',
         )
 
         console.warn = origWarn
         expect(result).toBeUndefined()
-        expect(warns.some((w) => w.includes('slow-fn') && w.includes('timed out'))).toBe(true)
+        expect(
+            warns.some((w) => w.includes('slow-fn') && w.includes('timed out')),
+        ).toBe(true)
     })
 })
 
@@ -372,7 +363,9 @@ describe('composeOutput with pluginContextResults', () => {
             globals: baseGlobals,
         })
         const parsed = JSON.parse(output)
-        expect(parsed.hookSpecificOutput.additionalContext).toContain('pane info')
+        expect(parsed.hookSpecificOutput.additionalContext).toContain(
+            'pane info',
+        )
     })
 
     test('pluginContextResults appear after injections and before meta', () => {
@@ -409,7 +402,9 @@ describe('composeOutput with pluginContextResults', () => {
             globals: baseGlobals,
         })
         const parsed = JSON.parse(output)
-        expect(parsed.hookSpecificOutput.additionalContext).not.toContain('plugin')
+        expect(parsed.hookSpecificOutput.additionalContext).not.toContain(
+            'plugin',
+        )
     })
 
     test('multiple pluginContextResults are all included', () => {

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from 'bun:test'
+import type {
+    RCTPlugin,
+    PluginHookInput,
+    PluginTriggerResult,
+} from '../src/plugin/types'
+import type { HookEvent } from '../src/config/types'
+
+describe('RCTPlugin context function', () => {
+    test('plugin with context function is valid', () => {
+        const plugin: RCTPlugin = {
+            name: 'test-context',
+            context: (_event: HookEvent, _input: PluginHookInput) => {
+                return 'some context'
+            },
+        }
+        expect(plugin.context).toBeDefined()
+        expect(plugin.name).toBe('test-context')
+    })
+
+    test('plugin without context function still works (backwards compatible)', () => {
+        const plugin: RCTPlugin = {
+            name: 'no-context',
+            files: [],
+            rules: [],
+        }
+        expect(plugin.context).toBeUndefined()
+    })
+
+    test('context returning undefined produces no output', () => {
+        const plugin: RCTPlugin = {
+            name: 'undefined-context',
+            context: () => undefined,
+        }
+        const result = plugin.context!('SessionStart', {
+            payload: {},
+        })
+        expect(result).toBeUndefined()
+    })
+
+    test('context returning a string appends to additionalContext', () => {
+        const plugin: RCTPlugin = {
+            name: 'string-context',
+            context: () => '<tmux>pane layout here</tmux>',
+        }
+        const result = plugin.context!('SessionStart', {
+            payload: {},
+        })
+        expect(result).toBe('<tmux>pane layout here</tmux>')
+    })
+
+    test('context that throws is caught and warned (not fatal)', async () => {
+        const plugin: RCTPlugin = {
+            name: 'throwing-context',
+            context: () => {
+                throw new Error('context exploded')
+            },
+        }
+        // The function itself throws — the pipeline must catch it
+        expect(() =>
+            plugin.context!('SessionStart', { payload: {} }),
+        ).toThrow('context exploded')
+    })
+
+    test('async context functions are awaited', async () => {
+        const plugin: RCTPlugin = {
+            name: 'async-context',
+            context: async () => {
+                return 'async result'
+            },
+        }
+        const result = await plugin.context!('SessionStart', {
+            payload: {},
+        })
+        expect(result).toBe('async result')
+    })
+
+    test('context receives event and input', () => {
+        let receivedEvent: HookEvent | undefined
+        let receivedInput: PluginHookInput | undefined
+
+        const plugin: RCTPlugin = {
+            name: 'input-check',
+            context: (event, input) => {
+                receivedEvent = event
+                receivedInput = input
+                return 'ok'
+            },
+        }
+
+        plugin.context!('PreToolUse', {
+            toolName: 'Bash',
+            payload: { tool_name: 'Bash', tool_input: { command: 'ls' } },
+        })
+
+        expect(receivedEvent).toBe('PreToolUse')
+        expect(receivedInput?.toolName).toBe('Bash')
+        expect(receivedInput?.payload.tool_name).toBe('Bash')
+    })
+})
+
+describe('RCTPlugin trigger function', () => {
+    test('plugin with trigger function is valid', () => {
+        const plugin: RCTPlugin = {
+            name: 'test-trigger',
+            trigger: (_event: HookEvent, _input: PluginHookInput) => {
+                return { action: 'block', message: 'blocked' }
+            },
+        }
+        expect(plugin.trigger).toBeDefined()
+    })
+
+    test('plugin without trigger function still works', () => {
+        const plugin: RCTPlugin = {
+            name: 'no-trigger',
+        }
+        expect(plugin.trigger).toBeUndefined()
+    })
+
+    test('trigger returning undefined takes no action', () => {
+        const plugin: RCTPlugin = {
+            name: 'undefined-trigger',
+            trigger: () => undefined,
+        }
+        const result = plugin.trigger!('PreToolUse', {
+            payload: {},
+        })
+        expect(result).toBeUndefined()
+    })
+
+    test('trigger returning block action blocks the tool use', () => {
+        const plugin: RCTPlugin = {
+            name: 'block-trigger',
+            trigger: () => ({
+                action: 'block' as const,
+                message: 'This tool is not allowed',
+            }),
+        }
+        const result = plugin.trigger!('PreToolUse', {
+            toolName: 'Bash',
+            payload: { tool_name: 'Bash' },
+        }) as PluginTriggerResult
+        expect(result.action).toBe('block')
+        expect(result.message).toBe('This tool is not allowed')
+    })
+
+    test('trigger returning warn action adds a warning', () => {
+        const plugin: RCTPlugin = {
+            name: 'warn-trigger',
+            trigger: () => ({
+                action: 'warn' as const,
+                message: 'Be careful with this tool',
+            }),
+        }
+        const result = plugin.trigger!('PreToolUse', {
+            payload: {},
+        }) as PluginTriggerResult
+        expect(result.action).toBe('warn')
+        expect(result.message).toBe('Be careful with this tool')
+    })
+
+    test('trigger that throws is caught and warned (not fatal)', () => {
+        const plugin: RCTPlugin = {
+            name: 'throwing-trigger',
+            trigger: () => {
+                throw new Error('trigger exploded')
+            },
+        }
+        expect(() =>
+            plugin.trigger!('PreToolUse', { payload: {} }),
+        ).toThrow('trigger exploded')
+    })
+
+    test('async trigger functions are awaited', async () => {
+        const plugin: RCTPlugin = {
+            name: 'async-trigger',
+            trigger: async () => {
+                return { action: 'warn' as const, message: 'async warning' }
+            },
+        }
+        const result = await plugin.trigger!('PreToolUse', {
+            payload: {},
+        })
+        expect(result).toEqual({
+            action: 'warn',
+            message: 'async warning',
+        })
+    })
+
+    test('trigger receives event and input', () => {
+        let receivedEvent: HookEvent | undefined
+        let receivedInput: PluginHookInput | undefined
+
+        const plugin: RCTPlugin = {
+            name: 'input-check-trigger',
+            trigger: (event, input) => {
+                receivedEvent = event
+                receivedInput = input
+                return undefined
+            },
+        }
+
+        plugin.trigger!('PostToolUse', {
+            toolName: 'Write',
+            payload: { tool_name: 'Write' },
+        })
+
+        expect(receivedEvent).toBe('PostToolUse')
+        expect(receivedInput?.toolName).toBe('Write')
+    })
+})
+
+describe('RCTPlugin with both context and trigger', () => {
+    test('plugin can have both context and trigger', () => {
+        const plugin: RCTPlugin = {
+            name: 'full-plugin',
+            files: [],
+            rules: [],
+            context: () => 'some context',
+            trigger: () => ({ action: 'warn' as const, message: 'heads up' }),
+        }
+        expect(plugin.context).toBeDefined()
+        expect(plugin.trigger).toBeDefined()
+        expect(plugin.files).toEqual([])
+        expect(plugin.rules).toEqual([])
+    })
+
+    test('plugin with only dynamic functions (no files/rules) is valid', () => {
+        const plugin: RCTPlugin = {
+            name: 'dynamic-only',
+            context: () => 'context',
+            trigger: () => undefined,
+        }
+        expect(plugin.name).toBe('dynamic-only')
+        expect(plugin.files).toBeUndefined()
+        expect(plugin.rules).toBeUndefined()
+    })
+})

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -7,6 +7,8 @@ import type {
 import type { HookEvent } from '../src/config/types'
 import { applyPlugins, type ValidatedConfig } from '../src/config/schema'
 import type { PluginExtensions } from '../src/config/schema'
+import { composeOutput } from '../src/engine/compose'
+import { withTimeout } from '../src/cli/hook'
 
 describe('RCTPlugin context function', () => {
     test('plugin with context function is valid', () => {
@@ -295,5 +297,135 @@ describe('applyPlugins extensions', () => {
             expect(typeof trg.name).toBe('string')
             expect(typeof trg.fn).toBe('function')
         }
+    })
+})
+
+// Step 3: withTimeout helper
+
+describe('withTimeout', () => {
+    test('returns value from sync function', async () => {
+        const result = await withTimeout(() => 'hello', 5000, 'test')
+        expect(result).toBe('hello')
+    })
+
+    test('returns value from async function', async () => {
+        const result = await withTimeout(async () => 'async hello', 5000, 'test')
+        expect(result).toBe('async hello')
+    })
+
+    test('returns undefined and warns on throw', async () => {
+        const warns: string[] = []
+        const origWarn = console.warn
+        console.warn = (...args: unknown[]) => warns.push(String(args[0]))
+
+        const result = await withTimeout(
+            () => {
+                throw new Error('boom')
+            },
+            5000,
+            'test-fn',
+        )
+
+        console.warn = origWarn
+        expect(result).toBeUndefined()
+        expect(warns.some((w) => w.includes('test-fn') && w.includes('boom'))).toBe(true)
+    })
+
+    test('returns undefined on timeout', async () => {
+        const warns: string[] = []
+        const origWarn = console.warn
+        console.warn = (...args: unknown[]) => warns.push(String(args[0]))
+
+        const result = await withTimeout(
+            () => new Promise<string>((resolve) => setTimeout(() => resolve('late'), 10000)),
+            50,
+            'slow-fn',
+        )
+
+        console.warn = origWarn
+        expect(result).toBeUndefined()
+        expect(warns.some((w) => w.includes('slow-fn') && w.includes('timed out'))).toBe(true)
+    })
+})
+
+// Step 3: composeOutput with pluginContextResults
+
+describe('composeOutput with pluginContextResults', () => {
+    const baseGlobals = {
+        format: 'xml' as const,
+        wrapper: 'context',
+        briefByDefault: false,
+        minify: true,
+        plugins: [],
+    }
+
+    test('includes pluginContextResults in output', () => {
+        const output = composeOutput({
+            event: 'SessionStart',
+            blockResult: null,
+            warnMessages: [],
+            injectionResults: [],
+            pluginContextResults: ['<tmux>pane info</tmux>'],
+            metaResult: null,
+            langResult: null,
+            testResult: null,
+            globals: baseGlobals,
+        })
+        const parsed = JSON.parse(output)
+        expect(parsed.hookSpecificOutput.additionalContext).toContain('pane info')
+    })
+
+    test('pluginContextResults appear after injections and before meta', () => {
+        const output = composeOutput({
+            event: 'SessionStart',
+            blockResult: null,
+            warnMessages: [],
+            injectionResults: ['<injection>data</injection>'],
+            pluginContextResults: ['<plugin>ctx</plugin>'],
+            metaResult: '<meta>info</meta>',
+            langResult: null,
+            testResult: null,
+            globals: baseGlobals,
+        })
+        const parsed = JSON.parse(output)
+        const ctx = parsed.hookSpecificOutput.additionalContext
+        const injIdx = ctx.indexOf('injection')
+        const plugIdx = ctx.indexOf('plugin')
+        const metaIdx = ctx.indexOf('meta')
+        expect(injIdx).toBeLessThan(plugIdx)
+        expect(plugIdx).toBeLessThan(metaIdx)
+    })
+
+    test('empty pluginContextResults produces no extra output', () => {
+        const output = composeOutput({
+            event: 'SessionStart',
+            blockResult: null,
+            warnMessages: [],
+            injectionResults: ['<data>x</data>'],
+            pluginContextResults: [],
+            metaResult: null,
+            langResult: null,
+            testResult: null,
+            globals: baseGlobals,
+        })
+        const parsed = JSON.parse(output)
+        expect(parsed.hookSpecificOutput.additionalContext).not.toContain('plugin')
+    })
+
+    test('multiple pluginContextResults are all included', () => {
+        const output = composeOutput({
+            event: 'SessionStart',
+            blockResult: null,
+            warnMessages: [],
+            injectionResults: [],
+            pluginContextResults: ['<p1>one</p1>', '<p2>two</p2>'],
+            metaResult: null,
+            langResult: null,
+            testResult: null,
+            globals: baseGlobals,
+        })
+        const parsed = JSON.parse(output)
+        expect(parsed.hookSpecificOutput.additionalContext).toContain('one')
+        expect(parsed.hookSpecificOutput.additionalContext).toContain('two')
     })
 })

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -350,9 +350,9 @@ describe('withTimeout', () => {
 
         const result = await withTimeout(
             () =>
-                new Promise<string>((resolve) =>
-                    setTimeout(() => resolve('late'), 10000),
-                ),
+                // Simulate a never-resolving operation without scheduling timers,
+                // so the test exercises the timeout path without background work.
+                new Promise<string>(() => {}),
             50,
             'slow-fn',
         )

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, test, mock } from 'bun:test'
 import type {
     RCTPlugin,
     PluginHookInput,
     PluginTriggerResult,
 } from '../src/plugin/types'
 import type { HookEvent } from '../src/config/types'
+import { applyPlugins, type ValidatedConfig } from '../src/config/schema'
+import type { PluginExtensions } from '../src/config/schema'
 
 describe('RCTPlugin context function', () => {
     test('plugin with context function is valid', () => {
@@ -234,5 +236,64 @@ describe('RCTPlugin with both context and trigger', () => {
         expect(plugin.name).toBe('dynamic-only')
         expect(plugin.files).toBeUndefined()
         expect(plugin.rules).toBeUndefined()
+    })
+})
+
+// Step 2: applyPlugins preserves context and trigger functions
+
+// Helper to create a mock resolvePlugin that returns given plugins
+function makeValidatedConfig(
+    pluginNames: string[],
+    overrides?: Partial<ValidatedConfig>,
+): ValidatedConfig {
+    return {
+        globals: {
+            format: 'xml',
+            wrapper: 'context',
+            briefByDefault: false,
+            minify: true,
+            plugins: pluginNames,
+        },
+        ...overrides,
+    }
+}
+
+describe('applyPlugins extensions', () => {
+    // We can't easily mock resolvePlugin imports, so we test the PluginExtensions
+    // interface and returned shape. The integration is tested via hook pipeline tests.
+
+    test('applyPlugins returns config and extensions object', async () => {
+        // With no plugins, extensions should be empty
+        const config = makeValidatedConfig([])
+        const result = await applyPlugins(config)
+        expect(result.config).toBeDefined()
+        expect(result.extensions).toBeDefined()
+        expect(result.extensions.contexts).toEqual([])
+        expect(result.extensions.triggers).toEqual([])
+    })
+
+    test('applyPlugins with built-in plugins (no context/trigger) returns empty extensions', async () => {
+        const config = makeValidatedConfig(['track-work', 'issue-scope'])
+        const result = await applyPlugins(config)
+        // Built-in plugins don't have context/trigger
+        expect(result.extensions.contexts).toEqual([])
+        expect(result.extensions.triggers).toEqual([])
+        // But files/rules should still be merged
+        expect(result.config.files?.length).toBeGreaterThan(0)
+    })
+
+    test('extensions functions are paired with plugin names', async () => {
+        // This tests the shape — the actual plugin resolution is tested in integration
+        const config = makeValidatedConfig([])
+        const result = await applyPlugins(config)
+        // Verify shape
+        for (const ctx of result.extensions.contexts) {
+            expect(typeof ctx.name).toBe('string')
+            expect(typeof ctx.fn).toBe('function')
+        }
+        for (const trg of result.extensions.triggers) {
+            expect(typeof trg.name).toBe('string')
+            expect(typeof trg.fn).toBe('function')
+        }
     })
 })

--- a/test/plugin-dynamic.test.ts
+++ b/test/plugin-dynamic.test.ts
@@ -326,42 +326,48 @@ describe('withTimeout', () => {
     test('returns undefined and warns on throw', async () => {
         const warns: string[] = []
         const origWarn = console.warn
-        console.warn = (...args: unknown[]) => warns.push(String(args[0]))
+        try {
+            console.warn = (...args: unknown[]) => warns.push(String(args[0]))
 
-        const result = await withTimeout(
-            () => {
-                throw new Error('boom')
-            },
-            5000,
-            'test-fn',
-        )
+            const result = await withTimeout(
+                () => {
+                    throw new Error('boom')
+                },
+                5000,
+                'test-fn',
+            )
 
-        console.warn = origWarn
-        expect(result).toBeUndefined()
-        expect(
-            warns.some((w) => w.includes('test-fn') && w.includes('boom')),
-        ).toBe(true)
+            expect(result).toBeUndefined()
+            expect(
+                warns.some((w) => w.includes('test-fn') && w.includes('boom')),
+            ).toBe(true)
+        } finally {
+            console.warn = origWarn
+        }
     })
 
     test('returns undefined on timeout', async () => {
         const warns: string[] = []
         const origWarn = console.warn
-        console.warn = (...args: unknown[]) => warns.push(String(args[0]))
+        try {
+            console.warn = (...args: unknown[]) => warns.push(String(args[0]))
 
-        const result = await withTimeout(
-            () =>
-                // Simulate a never-resolving operation without scheduling timers,
-                // so the test exercises the timeout path without background work.
-                new Promise<string>(() => {}),
-            50,
-            'slow-fn',
-        )
+            const result = await withTimeout(
+                () =>
+                    // Simulate a never-resolving operation without scheduling timers,
+                    // so the test exercises the timeout path without background work.
+                    new Promise<string>(() => {}),
+                50,
+                'slow-fn',
+            )
 
-        console.warn = origWarn
-        expect(result).toBeUndefined()
-        expect(
-            warns.some((w) => w.includes('slow-fn') && w.includes('timed out')),
-        ).toBe(true)
+            expect(result).toBeUndefined()
+            expect(
+                warns.some((w) => w.includes('slow-fn') && w.includes('timed out')),
+            ).toBe(true)
+        } finally {
+            console.warn = origWarn
+        }
     })
 })
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -315,14 +315,14 @@ describe('applyPlugins', () => {
         const config = validateConfig({
             files: [{ alias: 'mine', path: 'mine.xml' }],
         })
-        const result = await applyPlugins(config)
+        const { config: result } = await applyPlugins(config)
         expect(result.files).toHaveLength(1)
         expect(result.rules).toBeUndefined()
     })
 
     test('merges track-work plugin files into config.files', async () => {
         const config = validateConfig({ globals: { plugins: ['track-work'] } })
-        const result = await applyPlugins(config)
+        const { config: result } = await applyPlugins(config)
         const aliases = (result.files ?? []).map((f) => f.alias)
         expect(aliases).toContain('chores')
         expect(aliases).toContain('plans')
@@ -333,7 +333,7 @@ describe('applyPlugins', () => {
             globals: { plugins: ['track-work'] },
             files: [{ alias: 'my-file', path: 'my-file.xml' }],
         })
-        const result = await applyPlugins(config)
+        const { config: result } = await applyPlugins(config)
         const aliases = (result.files ?? []).map((f) => f.alias)
         expect(aliases).toContain('my-file')
         expect(aliases).toContain('chores')
@@ -341,7 +341,7 @@ describe('applyPlugins', () => {
 
     test('desugar after applyPlugins generates injections for plugin files with injectOn', async () => {
         const config = validateConfig({ globals: { plugins: ['track-work'] } })
-        const applied = await applyPlugins(config)
+        const { config: applied } = await applyPlugins(config)
         const desugared = desugarFileInjections(applied)
         const refs = (desugared.injections ?? []).flatMap((i) => i.inject)
         expect(refs).toContain('chores')
@@ -352,7 +352,7 @@ describe('applyPlugins', () => {
         const config = validateConfig({
             globals: { plugins: ['nonexistent-plugin'] },
         })
-        const result = await applyPlugins(config)
+        const { config: result } = await applyPlugins(config)
         expect(result.files ?? []).toHaveLength(0)
     })
 })


### PR DESCRIPTION
## Summary

- Extend `RCTPlugin` interface with optional `context()` and `trigger()` functions
- Integrate into hook pipeline: triggers evaluated before static rules (early exit on block), contexts evaluated concurrently after injections
- `applyPlugins()` returns `{ config, extensions }` with runtime function-type guards for `context`/`trigger`
- `withTimeout()` helper isolates plugin failures and timeouts (5s per plugin)
- Fix pre-existing issues (plugin error visibility, silent ref failures, unused format param)
- Add end-to-end CLI hook integration tests (`test/hook-plugin.test.ts`) with fixture-based plugins covering trigger block, trigger warn, dynamic context injection, and error isolation

## Test plan

- Plugin with `context()` produces dynamic output
- Plugin with `trigger()` blocks with exit code 2
- Plugin with `trigger()` warns without blocking (message appears in `additionalContext`)
- Backwards compatibility (plugins without `context()`/`trigger()` still work)
- Error isolation (`context()`/`trigger()` failures don't break pipeline)
- Pre-existing issue fixes verified

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>