### PR TITLE
fix: prevent CLI hook from hanging on stdin reads

### DIFF
--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -22,6 +22,7 @@ import {
 
 const SYNC_EVENTS: HookEvent[] = ['SessionStart', 'Setup']
 const TIMEOUT_MS = parseInt(process.env.RCT_PLUGIN_TIMEOUT_MS ?? '5000')
+const STDIN_TIMEOUT_MS = parseInt(process.env.RCT_STDIN_TIMEOUT_MS ?? '5000')
 
 async function withTimeout<T>(
     fn: () => T | Promise<T>,
@@ -53,6 +54,38 @@ async function withTimeout<T>(
 }
 
 export { withTimeout }
+
+/**
+ * Read and parse the hook payload from stdin for async events.
+ *
+ * Sync events (SessionStart, Setup) receive no payload, so we skip stdin
+ * entirely. For async events we must avoid blocking forever: `Bun.stdin.json()`
+ * only resolves once stdin reaches EOF, so if the caller keeps the pipe open
+ * (or the command is run interactively with stdin attached to a TTY) the read
+ * never completes and the CLI hangs. We guard against both: an interactive TTY
+ * means there is no piped payload, and a bounded timeout ensures a non-closing
+ * pipe can never wedge the process. Either way we fall back to a payload that
+ * carries just the event name.
+ */
+async function readStdin(
+    event: HookEvent
+): Promise<PluginHookInput<HookEvent, { tool_name?: string }>> {
+    const fallback = { hook_event_name: event } as PluginHookInput<
+        HookEvent,
+        { tool_name?: string }
+    >
+
+    // Sync events have no stdin payload; a TTY means nothing was piped in.
+    if (SYNC_EVENTS.includes(event) || process.stdin.isTTY) return fallback
+
+    const parsed = await withTimeout(
+        () => Bun.stdin.json() as Promise<typeof fallback>,
+        STDIN_TIMEOUT_MS,
+        'stdin read'
+    )
+
+    return parsed ?? fallback
+}
 
 export default async function hook(event: HookEvent) {
     const { config, extensions, registry, globals } = await loadConfig()
@@ -94,16 +127,7 @@ export default async function hook(event: HookEvent) {
 
     // Evaluate plugin triggers (before static rules — early exit on block)
     const stdin: PluginHookInput<typeof event, { tool_name?: string }> =
-        SYNC_EVENTS.includes(event)
-            ? { hook_event_name: event }
-            : // Read stdin for async events
-              await Bun.stdin
-                  .json()
-                  .catch(err =>
-                      Bun.stderr
-                          .write(`[rct] stdin parse error: ${String(err)}`)
-                          .then(() => ({ hook_event_name: event }))
-                  )
+        await readStdin(event)
 
     const warnings = [] as string[]
     for (const { name, fn } of extensions.triggers) {

--- a/src/lib/hook.ts
+++ b/src/lib/hook.ts
@@ -18,8 +18,10 @@ type HookHandler = (input: RC.HookInput) => RC.HookJSONOutput | Promise<RC.HookJ
  */
 export function createHook(handler: HookHandler): void {
     let data = ''
-    process.stdin.on('data', (chunk: Buffer | string) => (data += chunk))
-    process.stdin.on('end', async () => {
+    let settled = false
+    const run = async () => {
+        if (settled) return
+        settled = true
         let input: RC.HookInput
         try {
             input = JSON.parse(data || '{}') as RC.HookInput
@@ -42,7 +44,17 @@ export function createHook(handler: HookHandler): void {
             )
             process.exit(2)
         }
-    })
+    }
+
+    // No piped payload when stdin is a TTY — run immediately rather than
+    // waiting on an 'end' event that will never fire (which would hang).
+    if (process.stdin.isTTY) {
+        void run()
+        return
+    }
+
+    process.stdin.on('data', (chunk: Buffer | string) => (data += chunk))
+    process.stdin.on('end', () => void run())
     process.stdin.on('error', err => {
         console.log(
             minify(JSON.stringify({ decision: 'block', stopReason: err.message }))

--- a/src/lib/register.ts
+++ b/src/lib/register.ts
@@ -18,16 +18,19 @@ function isError(e: unknown): e is Error {
 export async function dynamic(): Promise<AsyncHookJSONOutput> {
     return new Promise<AsyncHookJSONOutput>(resolve => {
         let data = ''
-        process.stdin.on('data', chunk => (data += chunk))
-        process.stdin.on('end', () => {
+        const parse = () => {
             try {
-                resolve({ ...JSON.parse(data), inject: standard })
+                resolve({ ...JSON.parse(data || '{}'), inject: standard })
             } catch (e: unknown) {
                 block({
                     stopReason: isError(e) ? e.message : 'An unknown error occurred.',
                 })
             }
-        })
+        }
+        // A TTY means nothing was piped in; 'end' would never fire and hang.
+        if (process.stdin.isTTY) return parse()
+        process.stdin.on('data', chunk => (data += chunk))
+        process.stdin.on('end', parse)
         process.stdin.on('error', ({ message }) => block({ stopReason: message }))
     })
 }


### PR DESCRIPTION
## Problem

`rct hook <event>` hangs indefinitely for async hook events. Sync events (`SessionStart`, `Setup`) return immediately because they skip stdin entirely — which is exactly why only those "worked" and everything else appeared to hang.

## Root cause

Async hook events read their payload with `Bun.stdin.json()`, which only resolves once stdin reaches **EOF**. There was no timeout and no TTY guard, so:

- Running the command interactively (stdin is a TTY) → stdin never closes → hangs forever.
- A caller that opens the stdin pipe but never sends EOF → hangs forever.

### Reproduction (before fix)

```
held-open stdin, PreToolUse   → exit 124 (hung)
held-open stdin, SessionStart → exit 0   (sync, never reads stdin)
piped JSON + EOF, PreToolUse  → exit 0   (normal Claude Code path works)
```

## Fix

A `readStdin()` helper in `src/cli/hook.ts` that guards on two fronts:

1. **TTY short-circuit** — if `process.stdin.isTTY`, nothing was piped in, so return `{ hook_event_name: event }` immediately (fixes the interactive hang).
2. **Bounded read** — wrap `Bun.stdin.json()` in the existing `withTimeout` (`RCT_STDIN_TIMEOUT_MS`, default 5s) so a never-closing pipe can't wedge the process; it falls back to the event-only payload.

The same TTY guard is applied to the library stdin readers `createHook()` (`src/lib/hook.ts`) and `dynamic()` (`src/lib/register.ts`), which shared the identical blocking-on-EOF pattern and would hang consumers' custom hooks the same way.

## Verification (after fix)

```
held-open stdin (never EOF) → exits at ~5s, exit 0  (was infinite hang)
piped JSON + EOF            → exit 0, instant       (normal path intact)
SessionStart sync          → exit 0, instant
```

- `test/hook.test.ts`, `test/integration.test.ts`, `test/lib-hook.test.ts`: all pass.
- Lint: 35 pre-existing errors before and after — this change adds none.

## Out of scope (pre-existing, not addressed here)

Found while debugging, failing identically on the base commit:
- `test/hook-plugin.test.ts` — 2 failures (plugin trigger block/warn produce no output).
- `test/update.test.ts` — crashes on invalid `settings.json`.

Happy to follow up on these separately.

https://claude.ai/code/session_015Dh9ug2wpsZkPXUFzu5QPM

---
_Generated by [Claude Code](https://claude.ai/code/session_015Dh9ug2wpsZkPXUFzu5QPM)_